### PR TITLE
Connect leaderboard to live accounts data, drop mock users, add search/filters

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
 		"dc:build:mailing": "docker compose -f project/docker-compose/local-compose.yml --env-file ./project/docker-compose/.env.local build mailing_app",
 		"dc:build:education": "docker compose -f project/docker-compose/local-compose.yml --env-file ./project/docker-compose/.env.local build education_app",
 		"dc:build:analytics": "docker compose -f project/docker-compose/local-compose.yml --env-file ./project/docker-compose/.env.local build analytics_app",
-		"dc:build:website": "docker compose -f project/docker-compose/local-compose.yml --env-file ./project/docker-compose/.env.local build website_app",
+		"dc:build:website": "docker compose -f project/docker-compose/local-compose.yml --env-file ./project/docker-compose/.env.local build website",
 		"dc:ps": "docker compose ps",
 		"dc:logs": "docker compose logs -f",
 		"dc:up:dev-server": "docker compose -f project/docker-compose/dev-compose.yml --env-file ./project/docker-compose/.env.dev up -d --build",

--- a/project/frontend/website/src/pages/leaderboard/leaderboard.service.spec.ts
+++ b/project/frontend/website/src/pages/leaderboard/leaderboard.service.spec.ts
@@ -1,0 +1,63 @@
+import { getInitials, groupUsersByDepartment, resolveDepartment, type RealUser } from './leaderboard.service';
+
+describe('resolveDepartment', () => {
+  it('returns the trimmed department when present', () => {
+    expect(resolveDepartment(' Finance ')).toBe('Finance');
+  });
+
+  it('falls back to Unassigned for null', () => {
+    expect(resolveDepartment(null)).toBe('Unassigned');
+  });
+
+  it('falls back to Unassigned for an empty string', () => {
+    expect(resolveDepartment(' ')).toBe('Unassigned');
+  });
+
+  it('falls back to Unassigned when undefined', () => {
+    expect(resolveDepartment()).toBe('Unassigned');
+  });
+});
+
+describe('getInitials', () => {
+  it('uses first and last name initials when a full name is present', () => {
+    expect(getInitials('Mr Bean')).toBe('MB');
+  });
+
+  it('falls back to the first two letters of a single-word name', () => {
+    expect(getInitials('Superman')).toBe('SU');
+  });
+
+  it('falls back to the email when no name is present', () => {
+    expect(getInitials(undefined, 'olifant@example.com')).toBe('OL');
+  });
+
+  it('falls back to ?? when neither the name nor the email is present', () => {
+    expect(getInitials()).toBe('??');
+  });
+});
+
+describe('groupUsersByDepartment', () => {
+  const baseUser: Omit<RealUser, 'id' | 'department' | 'xp'> = {
+    auth0Id: 'auth0|x',
+    email: 'x@example.com',
+    name: 'X',
+    role: 'user',
+    createdAt: '2026-06-01',
+  };
+
+  const users: RealUser[] = [
+    { ...baseUser, id: '1', department: 'Finance', xp: 100 },
+    { ...baseUser, id: '2', department: 'Finance', xp: 300 },
+    { ...baseUser, id: '3', department: null, xp: 50 },
+  ];
+
+  it('groups members by department and computes total/average XP', () => {
+    const finance = groupUsersByDepartment(users).find(g => g.department === 'Finance');
+    expect(finance).toEqual({ department: 'Finance', members: 2, totalXP: 400, averageXP: 200 });
+  });
+
+  it('buckets users without a department under Unassigned', () => {
+    const unassigned = groupUsersByDepartment(users).find(g => g.department === 'Unassigned');
+    expect(unassigned).toEqual({ department: 'Unassigned', members: 1, totalXP: 50, averageXP: 50 });
+  });
+});

--- a/project/frontend/website/src/pages/leaderboard/leaderboard.service.ts
+++ b/project/frontend/website/src/pages/leaderboard/leaderboard.service.ts
@@ -1,0 +1,62 @@
+import { API_BASE, authFetch } from '../../services/api';
+
+export interface RealUser {
+  id: string;
+  auth0Id: string;
+  email: string;
+  name: string;
+  role: string;
+  department: string | null;
+  xp: number;
+  createdAt: string;
+}
+
+export async function fetchLeaderboardUsers(): Promise<RealUser[]> {
+  const res = await authFetch(`${API_BASE}/accounts/users`);
+  if (!res.ok) throw new Error(`Failed to load users (${res.status})`);
+  return res.json() as Promise<RealUser[]>;
+}
+
+export function getInitials(name?: string, email?: string): string {
+  if (name?.trim()) {
+    const parts = name.trim().split(/\s+/);
+    return parts.length >= 2
+      ? (parts[0][0] + parts[parts.length - 1][0]).toUpperCase()
+      : parts[0].slice(0, 2).toUpperCase();
+  }
+  return (email ?? '??').slice(0, 2).toUpperCase();
+}
+
+// department field doesn't exist yet server-side (need to add in an update from backend)
+export function resolveDepartment(department?: string | null): string {
+  const trimmed = department?.trim();
+  if (!trimmed) return 'Unassigned';
+  return trimmed;
+}
+
+export interface DepartmentGroup {
+  department: string;
+  members: number;
+  totalXP: number;
+  averageXP: number;
+}
+
+// groups real users by department once that field is actually populated - "Unassigned" for now.
+export function groupUsersByDepartment(users: RealUser[]): DepartmentGroup[] {
+  const groups = new Map<string, RealUser[]>();
+  for (const u of users) {
+    const key = resolveDepartment(u.department);
+    const list = groups.get(key) ?? [];
+    list.push(u);
+    groups.set(key, list);
+  }
+  return Array.from(groups.entries()).map(([department, members]) => {
+    const totalXP = members.reduce((sum, m) => sum + (m.xp ?? 0), 0);
+    return {
+      department,
+      members: members.length,
+      totalXP,
+      averageXP: members.length ? Math.round(totalXP / members.length) : 0,
+    };
+  });
+}

--- a/project/frontend/website/src/pages/leaderboard/leaderboard.tsx
+++ b/project/frontend/website/src/pages/leaderboard/leaderboard.tsx
@@ -1,6 +1,9 @@
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { AppLayout } from "../../components/layout/app-layout";
-import { MockDepartmentLeaderboard, MockUserLeaderboard } from "../../data/mock-leaderboard-data";
+import { Badge, Card, Input, Select, Spinner } from "../../components/ui";
+import { useAuth } from "../../context/auth-context";
+import { useToast } from "../../context/toast-context";
+import { fetchLeaderboardUsers, getInitials, groupUsersByDepartment, resolveDepartment, type RealUser, } from "./leaderboard.service";
 
 interface LeaderboardProps {
   onNavigate: (path: string) => void;
@@ -8,68 +11,163 @@ interface LeaderboardProps {
 }
 
 type LeaderboardTab = 'users' | 'departments';
-
 type DepartmentRankMode = 'totalXP' | 'averageXP';
+type DepartmentSizeFilter = 'all' | 'large' | 'small';
+type LoadError = 'forbidden' | 'other' | null;
+
+interface UserRow {
+    id: string;
+    name: string;
+    department: string;
+    xp: number;
+    isSelf: boolean;
+}
+
+const MEDALS = ['🥇', '🥈', '🥉'];
 
 export default function Leaderboard({onNavigate, activePath}: LeaderboardProps) {
+    const { user } = useAuth();
+    const { addToast } = useToast();
     const [activeTab, setActiveTab] = useState<LeaderboardTab>('departments');
     const [departmentRankMode, setDepartmentRankMode] = useState<DepartmentRankMode>('totalXP');
+    const [sizeFilter, setSizeFilter] = useState<DepartmentSizeFilter>('all');
+    const [search, setSearch] = useState('');
+    const [realUsers, setRealUsers] = useState<RealUser[] | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [loadError, setLoadError] = useState<LoadError>(null);
 
-    const sortedUsers = useMemo( () => [...MockUserLeaderboard].sort((a,b) => b.xp - a.xp), [], );
-    const sortedDepartments = useMemo( () => [...MockDepartmentLeaderboard].sort((a,b) => b[departmentRankMode] - a[departmentRankMode]), [departmentRankMode], );
+    //Important: Leaderboard nav item should have no minRole as every registered user is supposed to be able
+    //to see it, not just admin/analyst. GET /api/accounts/users is restricted server-side to admin/analyst (RolesGuard)
+    
+    useEffect(() => {
+        let cancelled = false;
+        setLoading(true);
+        setLoadError(null);
+        fetchLeaderboardUsers()
+            .then(data => { if (!cancelled) setRealUsers(data); })
+            .catch((err: unknown) => {
+                if (cancelled) return;
+                const message = err instanceof Error ? err.message : '';
+                const forbidden = message.includes('(403)');
+                setLoadError(forbidden ? 'forbidden' : 'other');
+                if (!forbidden) {
+                    addToast({ type: 'error', title: 'Could not load leaderboard', message: 'Please try again.' });
+                }
+            })
+            .finally(() => { if (!cancelled) setLoading(false); });
+        return () => { cancelled = true; };
+    }, []);
+
+    const userRows: UserRow[] = useMemo(() => {
+        if (!realUsers) return [];
+        return realUsers
+            .map(u => ({
+                id: u.id,
+                name: u.name?.trim() ? u.name.trim() : u.email,
+                // resolveDepartment() falls back to "Unassigned" until it is tracked server-side
+                department: resolveDepartment(u.department),
+                xp: u.xp ?? 0,
+                isSelf: !!user && u.email === user.email,
+            }))
+            .sort((a, b) => b.xp - a.xp);
+    }, [realUsers, user]);
+
+    const filteredUserRows = useMemo(() => {
+        const q = search.trim().toLowerCase();
+        if (!q) return userRows;
+        return userRows.filter(u => u.name.toLowerCase().includes(q) || u.department.toLowerCase().includes(q));
+    }, [userRows, search]);
+
+    const departmentGroups = useMemo(
+        () => (realUsers ? groupUsersByDepartment(realUsers) : []),
+        [realUsers],
+    );
+
+    const sortedDepartments = useMemo(() => {
+        const q = search.trim().toLowerCase();
+        return departmentGroups
+            .filter(d => !q || d.department.toLowerCase().includes(q))
+            .filter(d => {
+                if (sizeFilter === 'large') return d.members > 1;
+                if (sizeFilter === 'small') return d.members <= 1;
+                return true;
+            })
+            .sort((a, b) => b[departmentRankMode] - a[departmentRankMode]);
+    }, [departmentGroups, sizeFilter, departmentRankMode, search]);
 
     return(
         <AppLayout activePath={activePath} onNavigate={onNavigate} title='Leaderboard' securityScore={72}> 
             <main style={{ background: 'var(--bg-page)', minHeight: '100%', padding: 24 }}>
                 <section style={{width: '100%'}}>
-                    <div
-                        style={{
-                            background: 'var(--bg-card)',
-                            border: '1px solid var(--border)',
-                            borderRadius: 'var(--radius-xl)',
-                            padding: 8,
-                            gap: 6,
-                            display: 'inline-flex',
-                            marginBottom: 24,
-                            boxShadow: 'var(--shadow-sm)',
-                        }}
-                    >
-                        <TabButton 
-                            active={activeTab === 'departments'}
-                            onClick={() => setActiveTab('departments')}
+                    <div style={{ display: 'flex', gap: 12, marginBottom: 20, flexWrap: 'wrap', alignItems: 'center' }}>
+                        <div
+                            style={{
+                                background: 'var(--bg-card)',
+                                border: '1px solid var(--border)',
+                                borderRadius: 'var(--radius-xl)',
+                                padding: 8,
+                                gap: 6,
+                                display: 'inline-flex',
+                                boxShadow: 'var(--shadow-sm)',
+                            }}
                         >
-                            Departments
-                        </TabButton>
+                            <TabButton 
+                                active={activeTab === 'departments'}
+                                onClick={() => setActiveTab('departments')}
+                            >
+                                Departments
+                            </TabButton>
 
-                        <TabButton 
-                            active={activeTab === 'users'}
-                            onClick={() => setActiveTab('users')}
-                        >
-                            Users
-                        </TabButton>
-                        
-                    </div>
+                            <TabButton 
+                                active={activeTab === 'users'}
+                                onClick={() => setActiveTab('users')}
+                            >
+                                Users
+                            </TabButton>
+                        </div>
                     
+                        <div style={{ flex: '1 1 220px', minWidth: 200 }}>
+                            <Input
+                               placeholder={activeTab === 'users' ? 'Search by name or department…' : 'Search by department…'}
+                               value={search}
+                               onChange={e => setSearch(e.target.value)}
+                               leftIcon={<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>}
+                            />
+                        </div>
+                    </div>
+
                     {activeTab === 'users' ? (
                         <LeaderboardCard title="User Leaderboard">
-                            <LeaderboardTable
-                                headers ={['Rank', 'Name', 'Department', 'XP']}
-                                rows={sortedUsers.map((user, index) =>[
-                                    `#${index + 1}`,
-                                    user.name,
-                                    user.department,
-                                    user.xp.toLocaleString(),
-                                ])}
-                            />
+                            <LeaderboardBody
+                                loading={loading}
+                                loadError={loadError}
+                                isEmpty={filteredUserRows.length === 0}
+                                emptyMessage="No users match your search."
+                            >
+                                <LeaderboardTable
+                                    headers ={['Rank', 'Name', 'Department', 'XP']}
+                                    rows={filteredUserRows.map((u, index) =>[
+                                        `#${index + 1}`,
+                                        <UserCell
+                                           key={u.id}
+                                           name={u.name}
+                                           isSelf={u.isSelf}
+                                           medal={MEDALS[index]}
+                                        />,
+                                        u.department,
+                                        u.xp.toLocaleString(),
+                                    ])}
+                                />
+                            </LeaderboardBody>
                         </LeaderboardCard>
                     ) : (
                         <LeaderboardCard
                             title="Departments Leaderboard"
                             action={
-                                <div style={{display: 'flex', gap: 6}}>
+                                <div style={{display: 'flex', gap: 6, flexWrap: 'wrap', alignItems: 'center'}}>
                                     <TabButton
-                                        active={departmentRankMode === 'totalXP'}
-                                        onClick={() => setDepartmentRankMode('totalXP')}
+                                       active={departmentRankMode === 'totalXP'}
+                                       onClick={() => setDepartmentRankMode('totalXP')}
                                     >
                                         Total XP
                                     </TabButton>
@@ -80,20 +178,37 @@ export default function Leaderboard({onNavigate, activePath}: LeaderboardProps) 
                                     >
                                         Average XP
                                     </TabButton>
-
+                                    
+                                    <Select
+                                        value={sizeFilter}
+                                        onChange={e => setSizeFilter(e.target.value as DepartmentSizeFilter)}
+                                        options={[
+                                           { value: 'all', label: 'All Sizes' },
+                                           { value: 'large', label: 'Larger Teams' },
+                                           { value: 'small', label: 'Smaller Teams' },
+                                        ]}
+                                        style={{ minWidth: 132 }}
+                                    />
                                 </div>
                             }
                         >
-                            <LeaderboardTable
-                                headers ={['Rank', 'Department', 'Members', 'Total XP', 'Average XP']}
-                                rows={sortedDepartments.map((department, index) =>[
-                                    `#${index + 1}`,
-                                    department.department,
-                                    department.members.toString(),
-                                    department.totalXP.toLocaleString(),
-                                    department.averageXP.toLocaleString(),
-                                ])}
-                            />
+                            <LeaderboardBody
+                                loading={loading}
+                                loadError={loadError}
+                                isEmpty={sortedDepartments.length === 0}
+                                emptyMessage="No departments match your filters."
+                            >
+                                <LeaderboardTable
+                                    headers ={['Rank', 'Department', 'Members', 'Total XP', 'Average XP']}
+                                    rows={sortedDepartments.map((department, index) =>[
+                                      `#${index + 1}`,
+                                      department.department,
+                                      department.members.toString(),
+                                      department.totalXP.toLocaleString(),
+                                      department.averageXP.toLocaleString(),
+                                    ])}
+                                />
+                            </LeaderboardBody>
                         </LeaderboardCard>
                     )}
                 </section>
@@ -126,27 +241,76 @@ function TabButton ({active, onClick, children,} : {
     );
 }
 
+function UserCell({ name, isSelf, medal }: { name: string; isSelf: boolean; medal?: string }) {
+    return (
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+            <div
+                style={{
+                    width: 28, height: 28, borderRadius: '50%', background: 'var(--color-primary)',
+                    display: 'flex', alignItems: 'center', justifyContent: 'center',
+                    fontSize: 10, fontWeight: 700, color: '#fff', flexShrink: 0,
+                }}
+            >
+              {getInitials(name)}
+            </div>
+            <span style={{ fontWeight: 600 }}>{name}</span>
+            {isSelf && <Badge variant="primary">You</Badge>}
+            {medal && <span style={{ fontSize: 16 }}>{medal}</span>}
+        </div>
+    );
+}
+
+function EmptyState({ message }: { message: string }) {
+    return (
+        <div style={{ padding: 32, textAlign: 'center', color: 'var(--text-muted)', fontSize: 13, 
+            fontFamily: 'Inter, system-ui, sans-serif' }}>
+            {message}
+        </div>
+    );
+}
+
+function LeaderboardBody({ loading, loadError, isEmpty, emptyMessage, children }: {
+    loading: boolean;
+    loadError: LoadError;
+    isEmpty: boolean;
+    emptyMessage: string;
+    children: React.ReactNode;
+}) {
+    if (loading) {
+        return (
+            <div style={{ padding: 48, display: 'flex', justifyContent: 'center' }}>
+                <Spinner size={24} />
+            </div>
+        );
+    }
+    if (loadError === 'forbidden') {
+        return (
+            <EmptyState message= "Your account isn't permitted to load the leaderboard yet (endpoint restriction: server-side)" />
+        );
+    }
+    if (loadError === 'other') {
+        return <EmptyState message= "Couldn't load the leaderboard right now. Please try again." />;
+    }
+    if (isEmpty) {
+        return <EmptyState message={emptyMessage} />;
+    }
+    return <>{children}</>;
+}
+
 function LeaderboardCard({title, action, children}: {
     title:string;
     action?: React.ReactNode;
     children: React.ReactNode;
 }) {
     return (
-        <section
-            style={{
-                background: 'var(--bg-card)',
-                overflow: 'hidden',
-                border: '1px solid var(--border)',
-                borderRadius: 'var(--radius-xl)',
-                boxShadow: 'var(--shadow-sm)',
-            }}
-        >
+        <Card>
             <div
                 style={{
-                    padding: 24,
-                    gap: 16,
+                    padding: '20px 24px 14px',
                     borderBottom: '1px solid var(--border)',
                     display: 'flex',
+                    flexWrap: 'wrap',
+                    gap: 12,
                     alignItems: 'center',
                     justifyContent: 'space-between',
                 }}
@@ -157,15 +321,16 @@ function LeaderboardCard({title, action, children}: {
                 {action}
             </div>
 
-            {children}
-
-        </section>
+            <div style={{ paddingTop: 4 }}>
+                {children}
+            </div>
+        </Card>
     );
 }
 
 function LeaderboardTable({headers, rows}: {
     headers: string[];
-    rows: string[][];
+    rows: React.ReactNode[][];
 }) {
     return(
         <div style={{overflowX: 'auto'}}>
@@ -190,15 +355,15 @@ function LeaderboardTable({headers, rows}: {
                 </thead>
 
                 <tbody>
-                    {rows.map((row) => (
-                        <tr key={row.join('-')} style={{ borderTop: '1px solid var(--border)' }}>
-                            {row.map((cell) => (
+                    {rows.map((row, i) => (
+                        <tr key={i} style={{ borderTop: '1px solid var(--border)' }}>
+                            {row.map((cell, j) => (
                                 <td
-                                    key={cell}
+                                    key={j}
                                     style={{
-                                        padding: '14px 16px',
-                                        color: 'var(--text-primary)',
-                                        fontSize: 13,
+                                      padding: '14px 16px',
+                                      color: 'var(--text-primary)',
+                                      fontSize: 13,
                                     }}
                                 >
                                 {cell}


### PR DESCRIPTION
Leaderboard now fetches real users via GET /api/accounts/users (through the gateway) instead of mock data. Departments tab is derived from that same real user list (grouped client-side), not a separate mock dataset.
Added `leaderboard.service.ts` (data layer + unit tests) and UI polish: search, department size filter, avatar initials, top-3 medals, "You" tag on your own row, shared loading/empty/error states.

Important: Backend work needed before this is fully live
1. GET /api/accounts/users appears to be admin/analyst-only server-side. This conflicts with UC-03 in the SRS ("As a user, I want to view a real-time leaderboard"), which applies to any logged-in user. Needs the RolesGuard loosened for this read, or another solution. Until then, plain user accounts see a "restricted, pending backend fix" message instead of the leaderboard.
2. Department is accepted at registration but never persisted to db. Accounts-service discards `RegisterDto.department` and hardcodes '' in the user.created event. Frontend already falls back to "Unassigned" and will pick up the real value automatically once fixed.
3. XP isn't live: a real XP module exists on the unmerged branch of Darius. Even once merged, I think api-gateway needs a new /api/xp/ proxy route before the frontend can call it.